### PR TITLE
Rewrite doc in md

### DIFF
--- a/R/JSmediation.R
+++ b/R/JSmediation.R
@@ -7,24 +7,24 @@
 #'  mediation analysis.
 #'
 #' @details The main functions of the \pkg{JSmediation} package follow an
-#'   \code{mdt_*} pattern. \code{mdt_*} family functions allow you to conduct
+#'   `mdt_*` pattern. `mdt_*` family functions allow you to conduct
 #'   joint-significance tests for various mediation models (see Judd, Yzerbyt, &
 #'   Muller, 2014; Muller, Judd, & Yzerbyt, 2005; Yzerbyt, Muller, Batailler, &
 #'   Judd, 2018).
 #'
-#'   The syntax for \code{mdt_*} family functions is usually the same. The first
-#'   argument is always a data frame (\code{data}) which is followed by the
-#'   variable names involved in the model (e.g., DV, IV). Because \code{mdt_*}
+#'   The syntax for `mdt_*` family functions is usually the same. The first
+#'   argument is always a data frame (`data`) which is followed by the
+#'   variable names involved in the model (e.g., DV, IV). Because `mdt_*`
 #'   family functions use non-standard evaluation, these variable names must
 #'   generally be specified unquoted.
 #'
-#'   \code{mdt_*} family functions allow you to create an object of class
-#'   \code{"mediation_model"} for which various methods are implemented. The
+#'   `mdt_*` family functions allow you to create an object of class
+#'   `"mediation_model"` for which various methods are implemented. The
 #'   \code{\link{add_index}} method computes the (moderated) indirect effect
 #'   index using Monte Carlo for the different mediation models
 #'   \pkg{JSmediation} offers.
 #'
-#'   See \code{vignette("jsmediation")} for a general introduction and overview
+#'   See `vignette("jsmediation")` for a general introduction and overview
 #'   of \pkg{JSmediation}.
 #'
 #' @references Muller, D., Judd, C. M., & Yzerbyt, V. Y. (2005). When moderation

--- a/R/JSmediation.R
+++ b/R/JSmediation.R
@@ -20,7 +20,7 @@
 #'
 #'   `mdt_*` family functions allow you to create an object of class
 #'   `"mediation_model"` for which various methods are implemented. The
-#'   \code{\link{add_index}} method computes the (moderated) indirect effect
+#'   [`add_index`] method computes the (moderated) indirect effect
 #'   index using Monte Carlo for the different mediation models
 #'   \pkg{JSmediation} offers.
 #'

--- a/R/add_index.R
+++ b/R/add_index.R
@@ -1,12 +1,12 @@
 #' @title Adds an indirect effect index to a fitted mediation model
 #'
-#' @description \code{\link{add_index}} is a generic function that adds a
+#' @description [`add_index`] is a generic function that adds a
 #'   (moderated) indirect effect index to an object created with an `mdt_*`
 #'   family function. This index is computed using Monte Carlo methods. This
 #'   function invokes particular methods depending of the class of the mediation
-#'   model. For example, with a model fitted with \code{\link{mdt_simple}},
-#'   \code{\link{add_index}} will invoke
-#'   \code{\link{add_index.simple_mediation}}.
+#'   model. For example, with a model fitted with [`mdt_simple`],
+#'   [`add_index`] will invoke
+#'   [`add_index.simple_mediation`].
 #'   
 #' @param mediation_model A mediation model fitted with an `mdt_*` family
 #'   function.

--- a/R/add_index.R
+++ b/R/add_index.R
@@ -1,21 +1,21 @@
 #' @title Adds an indirect effect index to a fitted mediation model
 #'
 #' @description \code{\link{add_index}} is a generic function that adds a
-#'   (moderated) indirect effect index to an object created with an \code{mdt_*}
+#'   (moderated) indirect effect index to an object created with an `mdt_*`
 #'   family function. This index is computed using Monte Carlo methods. This
 #'   function invokes particular methods depending of the class of the mediation
 #'   model. For example, with a model fitted with \code{\link{mdt_simple}},
 #'   \code{\link{add_index}} will invoke
 #'   \code{\link{add_index.simple_mediation}}.
 #'   
-#' @param mediation_model A mediation model fitted with an \code{mdt_*} family
+#' @param mediation_model A mediation model fitted with an `mdt_*` family
 #'   function.
 #' @param times Number of simulations to use to compute the Monte Carlo index's
 #'   confidence interval.
 #' @param level Alpha threshold to use for the confidence interval.
 #' @param ... Further arguments to be passed to specific methods.
 #'
-#' @return An object of the same class as \code{mediation_model}, but with index
+#' @return An object of the same class as `mediation_model`, but with index
 #'   added for later use.
 #'
 #' @export

--- a/R/apastylr.R
+++ b/R/apastylr.R
@@ -3,7 +3,7 @@
 #' @description Create an APA formatted report from the test of a specific term
 #'   in a linear model.
 #'
-#' @param model A linear model created using \code{lm()}.
+#' @param model A linear model created using `lm()`.
 #' @param term A character string representing a term in the linear model.
 #'
 #' @return An APA formatted character string.

--- a/R/build_contrast.R
+++ b/R/build_contrast.R
@@ -10,7 +10,7 @@
 #'
 #' @return A numeric vector.
 #'
-#' @details The \code{\link{lm}} method supports factor and character variables
+#' @details The [`lm`] method supports factor and character variables
 #'   by dummy coding them. Dummy coding can make the interpretation of regression
 #'   coefficient difficult or at least more difficult than contrast coding.
 #'   Contrast-coded-variable coefficients interpretation is particularly useful
@@ -25,7 +25,7 @@
 #'
 #'  head(ho_et_al)
 #'
-#' @seealso \code{\link{scale}} for centering continuous numeric variable.
+#' @seealso [`scale`] for centering continuous numeric variable.
 #'
 #' @export
 build_contrast <- function(vector, cond_a, cond_b) {

--- a/R/display_models.R
+++ b/R/display_models.R
@@ -2,11 +2,11 @@
 #'
 #' @description When conducting a joint-significance test, different models are
 #' fitted to the data. This function helps you see a summary of the models that
-#' have been used in an object of class \code{mediation_model}.
+#' have been used in an object of class `mediation_model`.
 #'
-#' @param mediation_model An object of class \code{mediation_model}.
+#' @param mediation_model An object of class `mediation_model`.
 #'
-#' @return A list of \code{summary.lm} objects.
+#' @return A list of `summary.lm` objects.
 #'
 #' @examples
 #' data(ho_et_al)

--- a/R/dohle_siegrist.R
+++ b/R/dohle_siegrist.R
@@ -8,7 +8,7 @@
 #'   complex drug names are perceived as more hazardous, which makes someone
 #'   less likely to buy the drug. Researchers used a within-subject design.
 #'
-#'   This data set is in a long-format, see \code{\link{mdt_within}} to conduct
+#'   This data set is in a long-format, see [`mdt_within`] to conduct
 #'   a within-participant mediation analysis with this data set.
 #'
 #' @format A data frame with 44 rows and 4 variables: 

--- a/R/dohle_siegrist_w.R
+++ b/R/dohle_siegrist_w.R
@@ -8,7 +8,7 @@
 #'   complex drug names are perceived as more hazardous, which makes someone
 #'   less likely to buy the drug. Researchers used a within-subject design.
 #'
-#'   This data set is in a wide format, see \code{\link{mdt_within_wide}} to
+#'   This data set is in a wide format, see [`mdt_within_wide`] to
 #'   conduct a within-participant mediation analysis with this dataset.
 #'
 #'@format A data frame with 22 rows and 5 variables: 

--- a/R/extract_models.R
+++ b/R/extract_models.R
@@ -41,7 +41,7 @@ extract_models.mediation_model <- function(mediation_model) {
 #'   fitted to the data. This function helps you access the models used in an
 #'   object of class `mediation_model`.
 #'
-#' @seealso \code{\link{extract_models}} to access a list of every model
+#' @seealso [`extract_models`] to access a list of every model
 #'   relevant to joint-significance testing.
 #'
 #' @param mediation_model An object of class `mediation_model`.

--- a/R/extract_models.R
+++ b/R/extract_models.R
@@ -2,11 +2,11 @@
 #'
 #' @description When conducting a joint-significant test, different models are
 #'   fitted to the data. This function helps accessing the models used in an
-#'   object of class \code{mediation_model}.
+#'   object of class `mediation_model`.
 #'
-#' @param mediation_model An object of class \code{mediation_model}.
+#' @param mediation_model An object of class `mediation_model`.
 #'
-#' @return A list of \code{lm} objects.
+#' @return A list of `lm` objects.
 #' 
 #' @family extract functions
 #'
@@ -39,15 +39,15 @@ extract_models.mediation_model <- function(mediation_model) {
 #'
 #' @description When conducting a joint-significant test, different models are
 #'   fitted to the data. This function helps you access the models used in an
-#'   object of class \code{mediation_model}.
+#'   object of class `mediation_model`.
 #'
 #' @seealso \code{\link{extract_models}} to access a list of every model
 #'   relevant to joint-significance testing.
 #'
-#' @param mediation_model An object of class \code{mediation_model}.
+#' @param mediation_model An object of class `mediation_model`.
 #' @param step An integer or a string corresponding to the model to extract.
 #'
-#' @return An \code{lm} object.
+#' @return An `lm` object.
 #'
 #' @family extract functions
 #' 
@@ -89,9 +89,9 @@ extract_model.mediation_model <- function(mediation_model, step = NULL) {
 #'
 #' @description When conducting a joint significant test, different models are
 #' fitted to the data. This function helps you access the models  used in an
-#' object of class \code{mediation_model}.
+#' object of class `mediation_model`.
 #'
-#' @param mediation_model An object of class \code{mediation_model}.
+#' @param mediation_model An object of class `mediation_model`.
 #'
 #' @return A data frame.
 #'

--- a/R/ho_et_al.R
+++ b/R/ho_et_al.R
@@ -13,7 +13,7 @@
 #'   discrimination control condition in the study conducted by Ho, Kteiley and
 #'   Chen (2017).
 #'
-#'   See \code{\link{mdt_simple}} and \code{\link{mdt_moderated}} to conduct a
+#'   See [`mdt_simple`] and [`mdt_moderated`] to conduct a
 #'   simple mediation or a moderated mediation analysis with this dataset.
 #'   
 #' @format A data frame with 824 rows and 5 variables: 

--- a/R/indirect_effect-methods.R
+++ b/R/indirect_effect-methods.R
@@ -1,9 +1,9 @@
-#' @title Print method for object of class \code{indirect_index}
+#' @title Print method for object of class `indirect_index`
 #'
 #' @description Print a summary for an indirect effect index created with
-#'   \code{add_index()} method.
+#'   `add_index()` method.
 #'
-#' @param x      An object of class \code{indirect_index}.
+#' @param x      An object of class `indirect_index`.
 #' @param digits How many significant digits are to be used for numerics.
 #' @param ...    Further arguments.
 #'

--- a/R/mdt_moderated.R
+++ b/R/mdt_moderated.R
@@ -1,7 +1,7 @@
 #' @title Fits a moderated mediation model
 #'
-#' @description Given a data frame, a predictor (\code{IV}), an outcome
-#'   (\code{DV}), a mediator (\code{M}), and a moderator (\code{Mod}) conducts a
+#' @description Given a data frame, a predictor (`IV`), an outcome
+#'   (`DV`), a mediator (`M`), and a moderator (`Mod`) conducts a
 #'   joint-significant test for moderated mediation (see Yzerbyt, Muller,
 #'   Batailler, & Judd, 2018).
 #'
@@ -66,7 +66,7 @@
 #'   
 #' @section Variable coding: Because joint-significance tests use linear models
 #'   behind the scenes, variables involved in the model have to be numeric.
-#'   \code{mdt_simple} will give an error if non-numeric variables are
+#'   `mdt_simple` will give an error if non-numeric variables are
 #'   specified in the model.
 #'
 #'   If you need to convert a dichotomous categorical variable to a numeric one,
@@ -75,7 +75,7 @@
 #'   Note that variable coding is especially important in models with multiple
 #'   predictors as is the case in the model used to conduct a joint-significance
 #'   test of moderated mediation. Muller et al. (2005) recommend using variables
-#'   that are either contrast-coded or centered. Using \code{mdt_moderated} with
+#'   that are either contrast-coded or centered. Using `mdt_moderated` with
 #'   a DV, a mediator, or a moderator that is neither contrast-coded nor
 #'   centered will give a warning message.
 #'

--- a/R/mdt_moderated.R
+++ b/R/mdt_moderated.R
@@ -70,7 +70,7 @@
 #'   specified in the model.
 #'
 #'   If you need to convert a dichotomous categorical variable to a numeric one,
-#'   please refer to the \code{\link{build_contrast}} function.
+#'   please refer to the [`build_contrast`] function.
 #'
 #'   Note that variable coding is especially important in models with multiple
 #'   predictors as is the case in the model used to conduct a joint-significance

--- a/R/mdt_moderated_index.R
+++ b/R/mdt_moderated_index.R
@@ -1,7 +1,7 @@
 #' @title add_index method for moderated mediation
 #'
 #' @description Adds the confidence interval for the index of moderated
-#'   mediation to a model fitted with \code{\link{mdt_moderated}}.
+#'   mediation to a model fitted with [`mdt_moderated`].
 #'
 #' @param mediation_model A mediation model of class
 #'   `"moderated_mediation"`.

--- a/R/mdt_moderated_index.R
+++ b/R/mdt_moderated_index.R
@@ -4,14 +4,14 @@
 #'   mediation to a model fitted with \code{\link{mdt_moderated}}.
 #'
 #' @param mediation_model A mediation model of class
-#'   \code{"moderated_mediation"}.
+#'   `"moderated_mediation"`.
 #' @param times Number of simulations to use to compute the Monte Carlo indirect
 #'   effect confidence interval.
 #' @param level Alpha threshold to use for the confidence interval.
 #' @param stage Moderated indirect effect's stage for which to compute the
-#'   confidence interval. Can be either \code{1} (or \code{"first"}) or \code{2}
-#'   (or \code{"second"}). To compute total indirect effect moderation index,
-#'   use \code{"total"}.
+#'   confidence interval. Can be either `1` (or `"first"`) or `2`
+#'   (or `"second"`). To compute total indirect effect moderation index,
+#'   use `"total"`.
 #' @param ... Further arguments passed to or from other methods.
 #'
 #' @details Indirect effect moderation index for moderated mediation uses

--- a/R/mdt_moderated_index.R
+++ b/R/mdt_moderated_index.R
@@ -22,13 +22,11 @@
 #'
 #'   \pkg{JSmediation} supports different types of mediated indirect effect
 #'   index: 
-#'   \itemize{ 
-#'     \item{Stage 1: }{computes the product between \eqn{a \times Mod}{a
-#'     * Mod} and \eqn{b}.}
-#'     \item{Stage 2: }{ computes the product between \eqn{a} and \eqn{b \times
-#'     Mod}{b * Mod}.}
-#'     \item{Total: }{ computes the sum of Stage 1 and Stage 2 distribution.}
-#'   }
+#'   * **Stage 1:** computes the product between \eqn{a \times Mod}{a * Mod} and
+#'     \eqn{b}.
+#'   * **Stage 2:** computes the product between \eqn{a} and \eqn{b \times
+#'      Mod}{b * Mod}.
+#'   * **Total:** computes the sum of Stage 1 and Stage 2 distribution.
 #'
 #' @examples
 #' ## getting a stage 1 moderated indirect effect index

--- a/R/mdt_simple.R
+++ b/R/mdt_simple.R
@@ -1,7 +1,7 @@
 #' @title Joint-significance test for simple mediation
 #'
-#' @description Given a data frame, a predictor (\code{IV}), an outcome
-#'   (\code{DV}), and a mediator (\code{M}), conducts a joint-significant test 
+#' @description Given a data frame, a predictor (`IV`), an outcome
+#'   (`DV`), and a mediator (`M`), conducts a joint-significant test 
 #'   for simple mediation (see Yzerbyt, Muller, Batailler, & Judd, 2018).
 #'
 #' @param data A data frame containing the variables to be used in the model.
@@ -55,7 +55,7 @@
 #'   
 #' @section Variable coding: Because joint-significance tests uses linear models
 #'   behind the scenes, variables involved in the model have to be numeric.
-#'   \code{mdt_simple} will give an error if non-numeric variables are
+#'   `mdt_simple` will give an error if non-numeric variables are
 #'   specified in the model.
 #'
 #'   To convert a dichotomous categorical variable to a numeric one, please

--- a/R/mdt_simple.R
+++ b/R/mdt_simple.R
@@ -59,7 +59,7 @@
 #'   specified in the model.
 #'
 #'   To convert a dichotomous categorical variable to a numeric one, please
-#'   refer to the \code{\link{build_contrast}} function.
+#'   refer to the [`build_contrast`] function.
 #'
 #' @references Cohen, J., & Cohen, P. (1983). \emph{Applied multiple
 #'   regression/correlation analysis for the behavioral sciences} (2nd ed).

--- a/R/mdt_simple_index.R
+++ b/R/mdt_simple_index.R
@@ -1,7 +1,7 @@
 #' @title add_index method for simple mediation
 #'
 #' @description Adds confidence interval for the index of  mediation to a model
-#'   fitted with \code{\link{mdt_simple}}.
+#'   fitted with [`mdt_simple`].
 #'
 #' @param mediation_model A mediation model of class `"simple_mediation"`.
 #' @param times Number of simulations to use to compute the Monte Carlo indirect

--- a/R/mdt_simple_index.R
+++ b/R/mdt_simple_index.R
@@ -3,7 +3,7 @@
 #' @description Adds confidence interval for the index of  mediation to a model
 #'   fitted with \code{\link{mdt_simple}}.
 #'
-#' @param mediation_model A mediation model of class \code{"simple_mediation"}.
+#' @param mediation_model A mediation model of class `"simple_mediation"`.
 #' @param times Number of simulations to use to compute the Monte Carlo indirect
 #'   effect confidence interval.
 #' @param level Alpha threshold to use for the confidence interval.

--- a/R/mdt_within.R
+++ b/R/mdt_within.R
@@ -27,18 +27,18 @@
 #'   the first within-participant condition and one for the second
 #'   within-participant condition. In addition, each row has one observation for
 #'   the outcome and one observation for the mediator (see
-#'   \code{\link{dohle_siegrist}} for an example.
+#'   [`dohle_siegrist`] for an example.
 #'
 #'   Because such formatting is not the most common among social scientists
 #'   interested in within-participant mediation, \pkg{JSmediation} contains the
-#'   \code{\link{mdt_within_wide}} function which handles wide-formatted data
+#'   [`mdt_within_wide`] function which handles wide-formatted data
 #'   input (but is syntax-inconsistent with other `mdt_*` family
 #'   functions).
 #'
 #' @section Variable coding: Models underlying within-participant mediation use
 #'   difference scores as DV (see Models section). Because the function input
 #'   does not allow the user to specify how the difference scores should be
-#'   computed, `mdt_within` has a default coding.
+#'   computed, [`mdt_within`] has a default coding.
 #'
 #'   `mdt_within`'s default behavior is to compute the difference score so
 #'   the total effect (the effect of \eqn{X} on \eqn{Y}) will be positive and

--- a/R/mdt_within.R
+++ b/R/mdt_within.R
@@ -1,7 +1,7 @@
 #' @title Joint-significance test for within-participant mediation
 #'
-#' @description Given a data frame, a predictor (\code{IV}), an outcome
-#'   (\code{DV}), a mediator (\code{M}), and a grouping variable (\code{group})
+#' @description Given a data frame, a predictor (`IV`), an outcome
+#'   (`DV`), a mediator (`M`), and a grouping variable (`group`)
 #'   conducts a joint-significant test for within-participant mediation (see
 #'   Yzerbyt, Muller, Batailler, & Judd, 2018).
 #'
@@ -15,14 +15,14 @@
 #' @param grouping an unquoted variable in the data frame which will be used as
 #'   the grouping variable.
 #' @param default_coding should the variable coding be the default? Defaults to
-#'   \code{TRUE}.
+#'   `TRUE`.
 #'
 #' @template mediation_model
 #' @template within_details
 #' @template within_models
 #'
-#' @section Data formatting: To be consistent with other \code{mdt_*} family
-#'   functions, \code{mdt_within} takes a long-format data frame as \code{data}
+#' @section Data formatting: To be consistent with other `mdt_*` family
+#'   functions, `mdt_within` takes a long-format data frame as `data`
 #'   argument. With this kind of format, each sampled unit has two rows, one for
 #'   the first within-participant condition and one for the second
 #'   within-participant condition. In addition, each row has one observation for
@@ -32,25 +32,25 @@
 #'   Because such formatting is not the most common among social scientists
 #'   interested in within-participant mediation, \pkg{JSmediation} contains the
 #'   \code{\link{mdt_within_wide}} function which handles wide-formatted data
-#'   input (but is syntax-inconsistent with other \code{mdt_*} family
+#'   input (but is syntax-inconsistent with other `mdt_*` family
 #'   functions).
 #'
 #' @section Variable coding: Models underlying within-participant mediation use
 #'   difference scores as DV (see Models section). Because the function input
 #'   does not allow the user to specify how the difference scores should be
-#'   computed, \code{mdt_within} has a default coding.
+#'   computed, `mdt_within` has a default coding.
 #'
-#'   \code{mdt_within}'s default behavior is to compute the difference score so
+#'   `mdt_within`'s default behavior is to compute the difference score so
 #'   the total effect (the effect of \eqn{X} on \eqn{Y}) will be positive and
 #'   compute the other difference scores accordingly. That is, if
-#'   \code{mdt_within} has to use \eqn{Y_{2i} - Y_{1i}} (instead of \eqn{Y_{1i}
+#'   `mdt_within` has to use \eqn{Y_{2i} - Y_{1i}} (instead of \eqn{Y_{1i}
 #'   - Y_{2i}}) so that \eqn{c_{11}} is positive, it will use \eqn{M_{2i} -
 #'   M_{1i}} (instead of \eqn{M_{1i} - M_{2i}} in the other models.
 #'   
 #'   User can choose to have a negative total effect by using the
-#'   \code{default_coding} argument.
+#'   `default_coding` argument.
 #'
-#'   Note that \code{DV} and \code{M} have to be numeric.
+#'   Note that `DV` and `M` have to be numeric.
 #'
 #' @references Judd, C. M., Kenny, D. A., & McClelland, G. H. (2001). Estimating
 #'   and testing mediation and moderation in within-subject designs.

--- a/R/mdt_within_index.R
+++ b/R/mdt_within_index.R
@@ -5,7 +5,7 @@
 #'   \code{\link{mdt_within}} or \code{\link{mdt_within_wide}}.
 #'   
 #' @param mediation_model A mediation model of class
-#'   \code{"within_participant_mediation"}.
+#'   `"within_participant_mediation"`.
 #' @param times Number of simulations to use to compute the Monte Carlo indirect
 #'   effect confidence interval.
 #' @param level Alpha threshold to use for the confidence interval.

--- a/R/mdt_within_index.R
+++ b/R/mdt_within_index.R
@@ -2,8 +2,8 @@
 #'
 #' @description Adds the confidence interval for the index of
 #'   within-participant mediation to a  model fitted with
-#'   \code{\link{mdt_within}} or \code{\link{mdt_within_wide}}.
-#'   
+#'   [`mdt_within`] or [`mdt_within_wide`].
+#'  
 #' @param mediation_model A mediation model of class
 #'   `"within_participant_mediation"`.
 #' @param times Number of simulations to use to compute the Monte Carlo indirect

--- a/R/mdt_within_wide.R
+++ b/R/mdt_within_wide.R
@@ -1,7 +1,7 @@
 #' @title Joint-significance test for simple mediation (wide-format input)
 #' 
-#' @description Given a data frame, a predictor (\code{IV}), an outcome
-#'   (\code{DV}), a mediator (\code{M}), and a grouping variable (\code{group})
+#' @description Given a data frame, a predictor (`IV`), an outcome
+#'   (`DV`), a mediator (`M`), and a grouping variable (`group`)
 #'   conducts a joint-significant test for within-participant mediation (see
 #'   Yzerbyt, Muller, Batailler, & Judd, 2018).
 #'   
@@ -15,8 +15,8 @@
 #' @param M_B an unquoted numeric variable in the data frame which will be used
 #'   as the mediatior variable value for the "b" independent variable condition.
 #'   
-#' @section Data formatting: To be consistent with other \code{mdt_*} family
-#'   functions, \code{mdt_within} takes a long-format data frame as \code{data}
+#' @section Data formatting: To be consistent with other `mdt_*` family
+#'   functions, `mdt_within` takes a long-format data frame as `data`
 #'   argument. With this kind of format, each sampled unit has two rows, one for
 #'   the first within-participant condition and one for the second
 #'   within-participant condition. In addition, each row has one observation for
@@ -26,12 +26,12 @@
 #'   Because such formatting is not the most common among social scientists
 #'   interested in within-participant mediation, \pkg{JSmediation} contains the
 #'   \code{\link{mdt_within_wide}} function which handles wide-formatted data
-#'   input (but is syntax-inconsistent with other \code{mdt_*} family
+#'   input (but is syntax-inconsistent with other `mdt_*` family
 #'   functions).
 #'
 #' @section Variable coding: Models underlying within-participant mediation use
-#'   difference scores as DV (see Models section).  \code{mdt_within_wide} uses
-#'   \code{M_A} \eqn{-} \code{M_B} and \code{DV_A} \eqn{-} \code{DV_B} in these
+#'   difference scores as DV (see Models section).  `mdt_within_wide` uses
+#'   `M_A` \eqn{-} `M_B` and `DV_A` \eqn{-} `DV_B` in these
 #'   models.
 #'
 #' @template mediation_model

--- a/R/mdt_within_wide.R
+++ b/R/mdt_within_wide.R
@@ -16,16 +16,16 @@
 #'   as the mediatior variable value for the "b" independent variable condition.
 #'   
 #' @section Data formatting: To be consistent with other `mdt_*` family
-#'   functions, `mdt_within` takes a long-format data frame as `data`
+#'   functions, [`mdt_within`] takes a long-format data frame as `data`
 #'   argument. With this kind of format, each sampled unit has two rows, one for
 #'   the first within-participant condition and one for the second
 #'   within-participant condition. In addition, each row has one observation for
 #'   the outcome and one observation for the mediator (see
-#'   \code{\link{dohle_siegrist}} for an example.
+#'   [`dohle_siegrist`] for an example.
 #'
 #'   Because such formatting is not the most common among social scientists
 #'   interested in within-participant mediation, \pkg{JSmediation} contains the
-#'   \code{\link{mdt_within_wide}} function which handles wide-formatted data
+#'   [`mdt_within_wide`] function which handles wide-formatted data
 #'   input (but is syntax-inconsistent with other `mdt_*` family
 #'   functions).
 #'

--- a/R/mediation_model_print.R
+++ b/R/mediation_model_print.R
@@ -1,9 +1,9 @@
-#' @title Print method for object of class \code{mediation_model}
+#' @title Print method for object of class `mediation_model`
 #'
 #' @description Print a summary for a mediation model represented by a
-#' \code{mediation_model} object.
+#'   `mediation_model` object.
 #'
-#' @param x      An object of class \code{mediation_model}.
+#' @param x      An object of class `mediation_model`.
 #' @param digits How many significant digits are to be used for numerics.
 #' @param ...    Further arguments.
 #'

--- a/R/utils-tidy-eval.R
+++ b/R/utils-tidy-eval.R
@@ -29,7 +29,6 @@
 #' section](https://adv-r.hadley.nz/metaprogramming.html) of [Advanced
 #' R](https://adv-r.hadley.nz).
 #'
-#' @md
 #' @name     tidyeval
 #' @keywords internal
 #' @importFrom rlang quo quos enquo enquos quo_name sym ensym syms

--- a/man/JSmediation-package.Rd
+++ b/man/JSmediation-package.Rd
@@ -10,18 +10,18 @@ mediation analysis.
 }
 \details{
 The main functions of the \pkg{JSmediation} package follow an
-\code{mdt_*} pattern. \code{mdt_*} family functions allow you to conduct
+\verb{mdt_*} pattern. \verb{mdt_*} family functions allow you to conduct
 joint-significance tests for various mediation models (see Judd, Yzerbyt, &
 Muller, 2014; Muller, Judd, & Yzerbyt, 2005; Yzerbyt, Muller, Batailler, &
 Judd, 2018).
 
-The syntax for \code{mdt_*} family functions is usually the same. The first
+The syntax for \verb{mdt_*} family functions is usually the same. The first
 argument is always a data frame (\code{data}) which is followed by the
-variable names involved in the model (e.g., DV, IV). Because \code{mdt_*}
+variable names involved in the model (e.g., DV, IV). Because \verb{mdt_*}
 family functions use non-standard evaluation, these variable names must
 generally be specified unquoted.
 
-\code{mdt_*} family functions allow you to create an object of class
+\verb{mdt_*} family functions allow you to create an object of class
 \code{"mediation_model"} for which various methods are implemented. The
 \code{\link{add_index}} method computes the (moderated) indirect effect
 index using Monte Carlo for the different mediation models

--- a/man/add_index.Rd
+++ b/man/add_index.Rd
@@ -7,7 +7,7 @@
 add_index(mediation_model, times = 5000, level = 0.05, ...)
 }
 \arguments{
-\item{mediation_model}{A mediation model fitted with an \code{mdt_*} family
+\item{mediation_model}{A mediation model fitted with an \verb{mdt_*} family
 function.}
 
 \item{times}{Number of simulations to use to compute the Monte Carlo index's
@@ -23,7 +23,7 @@ added for later use.
 }
 \description{
 \code{\link{add_index}} is a generic function that adds a
-(moderated) indirect effect index to an object created with an \code{mdt_*}
+(moderated) indirect effect index to an object created with an \verb{mdt_*}
 family function. This index is computed using Monte Carlo methods. This
 function invokes particular methods depending of the class of the mediation
 model. For example, with a model fitted with \code{\link{mdt_simple}},

--- a/man/add_index.moderated_mediation.Rd
+++ b/man/add_index.moderated_mediation.Rd
@@ -36,11 +36,11 @@ Yzerbyt, 2005).
 \pkg{JSmediation} supports different types of mediated indirect effect
 index:
 \itemize{
-\item{Stage 1: }{computes the product between \eqn{a \times Mod}{a
-    * Mod} and \eqn{b}.}
-\item{Stage 2: }{ computes the product between \eqn{a} and \eqn{b \times
-    Mod}{b * Mod}.}
-\item{Total: }{ computes the sum of Stage 1 and Stage 2 distribution.}
+\item \strong{Stage 1:} computes the product between \eqn{a \times Mod}{a * Mod} and
+\eqn{b}.
+\item \strong{Stage 2:} computes the product between \eqn{a} and \eqn{b \times
+     Mod}{b * Mod}.
+\item \strong{Total:} computes the sum of Stage 1 and Stage 2 distribution.
 }
 }
 \examples{

--- a/man/mdt_within.Rd
+++ b/man/mdt_within.Rd
@@ -108,7 +108,7 @@ and \eqn{c'_{31}}{c'31}.
 }
 
 \section{Data formatting}{
- To be consistent with other \code{mdt_*} family
+ To be consistent with other \verb{mdt_*} family
 functions, \code{mdt_within} takes a long-format data frame as \code{data}
 argument. With this kind of format, each sampled unit has two rows, one for
 the first within-participant condition and one for the second
@@ -119,7 +119,7 @@ the outcome and one observation for the mediator (see
 Because such formatting is not the most common among social scientists
 interested in within-participant mediation, \pkg{JSmediation} contains the
 \code{\link{mdt_within_wide}} function which handles wide-formatted data
-input (but is syntax-inconsistent with other \code{mdt_*} family
+input (but is syntax-inconsistent with other \verb{mdt_*} family
 functions).
 }
 

--- a/man/mdt_within.Rd
+++ b/man/mdt_within.Rd
@@ -127,7 +127,7 @@ functions).
  Models underlying within-participant mediation use
 difference scores as DV (see Models section). Because the function input
 does not allow the user to specify how the difference scores should be
-computed, \code{mdt_within} has a default coding.
+computed, \code{\link{mdt_within}} has a default coding.
 
 \code{mdt_within}'s default behavior is to compute the difference score so
 the total effect (the effect of \eqn{X} on \eqn{Y}) will be positive and

--- a/man/mdt_within_wide.Rd
+++ b/man/mdt_within_wide.Rd
@@ -80,7 +80,7 @@ simultaneously significant for an indirect effect to be claimed (Judd,
 Kenny, & McClelland, 2001; Montoya & Hayes, 2011).
 }
 \section{Data formatting}{
- To be consistent with other \code{mdt_*} family
+ To be consistent with other \verb{mdt_*} family
 functions, \code{mdt_within} takes a long-format data frame as \code{data}
 argument. With this kind of format, each sampled unit has two rows, one for
 the first within-participant condition and one for the second
@@ -91,7 +91,7 @@ the outcome and one observation for the mediator (see
 Because such formatting is not the most common among social scientists
 interested in within-participant mediation, \pkg{JSmediation} contains the
 \code{\link{mdt_within_wide}} function which handles wide-formatted data
-input (but is syntax-inconsistent with other \code{mdt_*} family
+input (but is syntax-inconsistent with other \verb{mdt_*} family
 functions).
 }
 

--- a/man/mdt_within_wide.Rd
+++ b/man/mdt_within_wide.Rd
@@ -81,7 +81,7 @@ Kenny, & McClelland, 2001; Montoya & Hayes, 2011).
 }
 \section{Data formatting}{
  To be consistent with other \verb{mdt_*} family
-functions, \code{mdt_within} takes a long-format data frame as \code{data}
+functions, \code{\link{mdt_within}} takes a long-format data frame as \code{data}
 argument. With this kind of format, each sampled unit has two rows, one for
 the first within-participant condition and one for the second
 within-participant condition. In addition, each row has one observation for


### PR DESCRIPTION
Use the markdown support of `roxygen2` to rewrite the documentation so it is easier to maintain. 

See: https://roxygen2.r-lib.org/articles/markdown.html#roxygen-and-rd-tags-not-parsed-as-markdown