### PR TITLE
Replace deprecated dplyr code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,8 @@ Imports:
     purrr,
     rlang (>= 0.4.9),
     stats,
-    tibble
+    tibble,
+    tidyselect
 Suggests: 
     covr,
     lavaan,

--- a/R/check_variables.R
+++ b/R/check_variables.R
@@ -1,21 +1,27 @@
-# Performs tests on a mediation_model object. Variable coding could impact
-# underlying linear model for mediation model like moderated mediation,
-# check_variables
-# Generic. Used for its side effect.
-# Args:
-#   model: a mediation_model object
+#' Performs tests on a mediation_model object. Variable coding could impact
+#' underlying linear model for mediation model like moderated mediation,
+#' check_variables
+#' Generic. Used for its side effect.
+#'
+#' @param model A `mediation_model` object.
+#'
+#' @noRd
 check_variables <- function(model) {
   UseMethod("check_variables")
 }
 
-# Default method for check_variables, do not perform any test.
+#' Default method for check_variables, do not perform any test.
+#'
+#' @noRd
 check_variables.default <- function(model) {
   NULL
 }
 
-# Method for moderated_mediation class. Checks whether IV, Mediator, or
-# Moderator is either a contrast-coded or a centered variable. Throws a
-# message if it is not the case.
+#' Method for moderated_mediation class. Checks whether IV, Mediator, or
+#' Moderator is either a contrast-coded or a centered variable. Throws a
+#' message if it is not the case.
+#'
+#' @noRd
 check_variables.moderated_mediation <- function(model) {
   IV_n <- purrr::pluck(model, "params", "IV")
   M_n <- purrr::pluck(model, "params", "M")

--- a/R/compute_indirect_effect_for.R
+++ b/R/compute_indirect_effect_for.R
@@ -114,7 +114,7 @@ compute_indirect_effect_for.moderated_mediation <-
     # adjust the moderator coding so that 0 is the value we want to look at
     mediation_dataset <-
       mediation_dataset %>%
-      dplyr::mutate(dplyr::across(.data[[moderator]], ~ .x - Mod))
+      dplyr::mutate(dplyr::across(tidyselect::all_of(moderator), ~ .x - Mod))
 
     # run a new moderated mediation model
     mediation_model_at_Mod <-

--- a/R/utils-tidy-eval.R
+++ b/R/utils-tidy-eval.R
@@ -36,5 +36,5 @@
 #' @aliases  quo quos enquo enquos quo_name
 #'           sym ensym syms ensyms
 #'           expr exprs enexpr enexprs
-#'           .data :=
+#'           :=
 NULL

--- a/man/tidyeval.Rd
+++ b/man/tidyeval.Rd
@@ -15,7 +15,6 @@
 \alias{exprs}
 \alias{enexpr}
 \alias{enexprs}
-\alias{.data}
 \alias{:=}
 \title{Tidy eval helpers}
 \description{


### PR DESCRIPTION
`.data` has been deprecated. It is now replaced by `tidyselect::all_of`